### PR TITLE
Updated computeNodeLinks to Search By Id.

### DIFF
--- a/src/sankey.js
+++ b/src/sankey.js
@@ -129,7 +129,11 @@ export default function Sankey() {
       node.sourceLinks = [];
       node.targetLinks = [];
     }
-    const nodeById = new Map(nodes.map((d, i) => [id(d, i, nodes), d]));
+    const nodeById = new Map([
+      ...nodes.map((d, i) => [id(d, i, nodes), d]), // Here we search against the usual index.
+      ...nodes.map((d, i) => [d.id, d]) // Here, we also search against the ID string.
+    ]);
+
     for (const [i, link] of links.entries()) {
       link.index = i;
       let {source, target} = link;


### PR DESCRIPTION
Simple Sankey applications only use Integer Ids to connect Node Links. This modification allows us to connect Node Links by an Id string.